### PR TITLE
Dashboard

### DIFF
--- a/cmsplugin_filer_link2/admin.py
+++ b/cmsplugin_filer_link2/admin.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+from django.conf.urls import url
 from django.contrib import admin
+from django.shortcuts import redirect
 from django.utils.safestring import mark_safe
 from django.utils.translation import activate
 from django.utils.translation import ugettext as _
 
+from cmsplugin_filer_link2.management.commands import check_links
 from .models import LinkHealthState
 
 
@@ -11,11 +14,45 @@ class LinkStateAdmin(admin.ModelAdmin):
     list_display = ('link_name', 'link_to', 'state', 'on_page', 'detected')
     list_filter = ('state',)
 
+    change_list_template = 'admin/cmsplugin_filer_link/change_list.html'
+
+    def changelist_view(self, request, extra_context=None):
+        context = {
+            'not_found_errors': LinkHealthState.objects.filter(state=LinkHealthState.NOT_REACHABLE),
+            'server_errors': LinkHealthState.objects.filter(state=LinkHealthState.SERVER_ERROR),
+            'redirected_links': LinkHealthState.objects.filter(state=LinkHealthState.REDIRECT),
+            'bad_configured_links': LinkHealthState.objects.filter(state=LinkHealthState.BAD_CONFIGURED),
+            'error_count': LinkHealthState.objects.all().count()
+        }
+        context.update(extra_context or {})
+        return super(LinkStateAdmin, self).changelist_view(request, context)
+
     def has_add_permission(self, request):
         return False
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def get_actions(self, request):
+        actions = super(LinkStateAdmin, self).get_actions(request)
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
+        return actions
+
+    def get_urls(self):
+        urlpatterns = super(LinkStateAdmin, self).get_urls()
+
+        link_health_state_custom_urls = [
+            url(r'^update-health-states/$', self.admin_site.admin_view(self.update_health_states),
+                name='%s_%s_update_health_state' % (self.model._meta.app_label, self.model._meta.model_name))
+        ]
+
+        return link_health_state_custom_urls + urlpatterns
+
+    def update_health_states(self, request):
+        cmd = check_links.Command()
+        cmd.handle()
+        return redirect('admin:%s_%s_changelist' % (self.model._meta.app_label, self.model._meta.model_name))
 
     def link_name(self, obj):
         return obj.link

--- a/cmsplugin_filer_link2/templates/admin/cmsplugin_filer_link/change_list.html
+++ b/cmsplugin_filer_link2/templates/admin/cmsplugin_filer_link/change_list.html
@@ -1,0 +1,101 @@
+{% extends 'admin/change_list.html' %}
+{% load i18n %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <style>
+        .link2-critical-error {
+            color: red;
+        }
+        .link2-warning {
+            color: #ffbb00
+        }
+        .error-list {
+            display: inline-block;
+            margin-right: 50px;
+        }
+        a.cms-btn.btn-analysis {
+            background-color: #0bf !important;
+            color: white !important;
+            display: inline-block;
+            padding: 8px 16px !important;
+            margin-bottom: 30px;
+            margin-top: 10px;
+        }
+        a.cms-btn.btn-analysis:hover {
+            color: white !important;
+            background-color: #00aaee !important;
+        }
+    </style>
+{% endblock %}
+
+{% block content_title %}
+    <h1>
+        {% trans 'Welcome to you link health state dashboard!' %}
+    </h1>
+{% endblock %}
+
+{% block content %}
+    {# Short error overview report. #}
+    {% if error_count %}
+        <div>
+            {% blocktrans count counter=error_count %}
+                We have identified 1 issue:
+            {% plural %}
+                We have identified {{ error_count }} issues:
+            {% endblocktrans %}
+        </div>
+        <ul class="error-list">
+            {% if redirected_links %}
+                <li class="link2-warning">
+                    {% blocktrans count counter=redirected_links|length %}
+                        1 link is
+                    {% plural %}
+                        {{ counter }} links are
+                    {% endblocktrans %}
+                    redirected (3xx).
+                </li>
+            {% endif %}
+            {% if not_found_errors %}
+                <li class="link2-critical-error">
+                    {% blocktrans count counter=not_found_errors|length %}
+                        1 link leads
+                    {% plural %}
+                        {{ counter }} links lead
+                    {% endblocktrans %}
+                    into a page which cannot be found (4xx).
+                </li>
+            {% endif %}
+            {% if server_errors %}
+                <li class="link2-critical-error">
+                    {% blocktrans count counter=server_errors|length %}
+                        1 link leads
+                    {% plural %}
+                        {{ counter }} links lead
+                    {% endblocktrans %}
+                    into a page which results in a server error (5xx).
+                </li>
+            {% endif %}
+            {% if bad_configured_links %}
+                <li class="link2-critical-error">
+                    {% blocktrans count counter=bad_configured_links|length %}
+                        1 link is
+                    {% plural %}
+                        {{ counter }} links are
+                    {% endblocktrans %}
+                    badly configured.
+                </li>
+            {% endif %}
+        </ul>
+    {% else %}
+        <div>
+            {% blocktrans %}
+                Everything seems to be fine!
+            {% endblocktrans %}
+        </div>
+    {% endif %}
+    <a class="cms-btn btn-analysis" href="{% url 'admin:cmsplugin_filer_link2_linkhealthstate_update_health_state' %}">{% trans 'Start link analysis' %}</a>
+    {{ block.super }}
+{% endblock %}
+
+{% block object_tools %}{% endblock %}


### PR DESCRIPTION
 - display amount of issues at top (3xx, 4xx, 5xx and bad configured)
 - removed action dropdown
 - adds button to start link analysis

Possible ToDo:
Make the link analysis asynchronous. Right now it is in the request - response cycle. That means the user could wait a pretty long time before all links have been analyze (because of low response times or timeouts...).