### PR TITLE
Don't render a space before/after the <a> tag

### DIFF
--- a/cmsplugin_filer_link2/templates/cmsplugin_filer_link/link.html
+++ b/cmsplugin_filer_link2/templates/cmsplugin_filer_link/link.html
@@ -2,6 +2,4 @@
     <span style="border-style: solid; border-color: red;">
         <a href="{{ link }}" class="{{ style }}"{% if new_window %} target="_blank"{% endif %} {{ instance.link_attributes_str }}><span style="font-family:'Arial';font-size:15px;color:black">{{ link_state }}:</span>{{ name }}</a>
     </span>
-{% else %}
-    <a href="{{ link }}" class="{{ style }}"{% if new_window %} target="_blank"{% endif %} {{ instance.link_attributes_str }}>{{ name }}</a>
-{% endif %}
+{% else %}<a href="{{ link }}" class="{{ style }}"{% if new_window %} target="_blank"{% endif %} {{ instance.link_attributes_str }}>{{ name }}</a>{% endif %}


### PR DESCRIPTION
This resolves the issue where a space gets's rendered eg. between the link and a period directly after it.