### PR TITLE
Ignore id anchor

### DIFF
--- a/cmsplugin_filer_link2/management/commands/check_links.py
+++ b/cmsplugin_filer_link2/management/commands/check_links.py
@@ -13,6 +13,8 @@ class Command(BaseCommand):
     help = 'Check all links for the availability of their destination'
 
     def check_with_request(self, url):
+        if url.startswith('#'):
+            return
         try:
             r = requests.get(url)
         except ConnectionError:

--- a/cmsplugin_filer_link2/management/commands/check_links.py
+++ b/cmsplugin_filer_link2/management/commands/check_links.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = 'Check all links for the availability of their destination'
 
     def check_with_request(self, url):
-        if url.startswith('#'):
+        if url and url.startswith('#'):
             return
         try:
             r = requests.get(url)


### PR DESCRIPTION
This pull request allows the link checker logic to ignore ID anchors and therefore does not mark those as invalid link anymore.