### PR TITLE
Add user agent support 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@
 * Blueshoe GmbH (blueshoe.de)
 
 * Michael Schilonka
+* Robert Stein

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.1.5 (2019-04-05)
+-----------------
+* add user agent to request (management command check_links)
+* add flag to disable user agent (management command check_links)
+
+
 1.1.4 (2019-04-03)
 ------------------
 * fixes bug that caused management command to crash with an InvalidSchema exception

--- a/cmsplugin_filer_link2/__init__.py
+++ b/cmsplugin_filer_link2/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '1.1.4'
+__version__ = '1.1.5'
 default_app_config = 'cmsplugin_filer_link2.apps.Link2'


### PR DESCRIPTION
Adds user agent to request headers since some pages block requests without a user agent.
The user agent can be disabled through by using `--no-agent`.

In case everything is fine please release :)